### PR TITLE
Update Reagent to 0.8.1

### DIFF
--- a/resources/leiningen/new/figwheel_heroku/project.clj
+++ b/resources/leiningen/new/figwheel_heroku/project.clj
@@ -8,7 +8,7 @@
   :repl-options {:init-ns dev.repl}
   :dependencies [[org.clojure/clojure "1.10.0-alpha4"]
                  [org.clojure/clojurescript "1.10.238"]
-                 [reagent "0.8.0-alpha2"]
+                 [reagent "0.8.1"]
                  [compojure "1.6.0"]
                  [ring/ring-jetty-adapter "1.6.2"]
                  [ring/ring-ssl "0.3.0"]


### PR DESCRIPTION
- Supports `[:<> ...]` Fragment syntax, see https://github.com/reagent-project/reagent/blob/master/CHANGELOG.md#080-2018-04-19